### PR TITLE
feat(regex): add support for regex matchers for dynamic params

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,21 +20,7 @@ function split(str) {
 }
 
 function isMatch(str, obj) {
-	return (obj.val === str && obj.type === STYPE) || (str === SEP ? obj.type > PTYPE : obj.type !== STYPE && (str || '').endsWith(obj.end) && (obj.matcher ? obj.matcher.test(str) : true));
-}
-
-function getMatcher (matchers, val) {
-	if (!matchers || !matchers[val]) {
-		return null;
-	}
-
-	const matcher = matchers[val];
-
-	if (typeof (matcher.test) !== 'function') {
-		throw new Error(`matcher for ${val} is not a regex`);
-	}
-
-	return matcher;
+	return (obj.val === str && obj.type === STYPE) || (str === SEP ? obj.type > PTYPE : obj.type !== STYPE && (str || '').endsWith(obj.end) && (!!obj.matcher ? obj.matcher.test(str) : true));
 }
 
 export function match(str, all) {
@@ -54,6 +40,16 @@ export function match(str, all) {
 export function parse(str, matchers) {
 	if (str === SEP) {
 		return [{ old:str, type:STYPE, val:str, end:'', matcher: null }];
+	}
+
+	if (typeof matchers === 'object') {
+		for (let k in matchers) {
+			if (matchers[k].constructor !== RegExp) {
+				throw new Error(`the "${k}" key is not a RegExp`);
+			}
+		}
+	} else {
+		matchers = {};
 	}
 
 	let c, x, t, sfx, val, nxt=strip(str), i=-1, j=0, len=nxt.length, out=[];
@@ -84,7 +80,7 @@ export function parse(str, matchers) {
 				type: t,
 				val: val,
 				end: sfx,
-				matcher: getMatcher(matchers, val)
+				matcher: matchers[val]
 			});
 
 			// shorten string & update pointers

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ export function match(str, all) {
 
 export function parse(str, matchers) {
 	if (str === SEP) {
-		return [{ old:str, type:STYPE, val:str, end:'', matcher: null }];
+		return [{ old:str, type:STYPE, val:str, end:'' }];
 	}
 
 	if (typeof matchers === 'object') {
@@ -92,8 +92,7 @@ export function parse(str, matchers) {
 				old: str,
 				type: ATYPE,
 				val: nxt.substring(i),
-				end: '',
-				matcher: null
+				end: ''
 			});
 			continue; // loop
 		} else {
@@ -108,8 +107,7 @@ export function parse(str, matchers) {
 				old: str,
 				type: STYPE,
 				val: val,
-				end: '',
-				matcher: getMatcher(matchers, val)
+				end: ''
 			});
 			// shorten string & update pointers
 			nxt=nxt.substring(i); len-=i; i=j=0;

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ export function parse(str, matchers) {
 		return [{ old:str, type:STYPE, val:str, end:'', matcher: null }];
 	}
 
-	let c, x, t, sfx, nxt=strip(str), i=-1, j=0, len=nxt.length, out=[];
+	let c, x, t, sfx, val, nxt=strip(str), i=-1, j=0, len=nxt.length, out=[];
 
 	while (++i < len) {
 		c = nxt.charCodeAt(i);
@@ -77,12 +77,12 @@ export function parse(str, matchers) {
 				i++; // move on
 			}
 
-			const val = nxt.substring(j, x||i);
+			val = nxt.substring(j, x||i);
 
 			out.push({
 				old: str,
 				type: t,
-				val,
+				val: val,
 				end: sfx,
 				matcher: getMatcher(matchers, val)
 			});
@@ -106,7 +106,7 @@ export function parse(str, matchers) {
 				++i; // skip to next slash
 			}
 
-			const val = nxt.substring(j, i);
+			val = nxt.substring(j, i);
 
 			out.push({
 				old: str,

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,8 @@ function isEntry(t, segs, expect) {
 	t.is(segs.length, expect.length, `~> entry has ${expect.length} segment(s)`)
 
 	segs.forEach((obj, idx) => {
-		t.is(Object.keys(obj).length, 5, '~~> segment has `old`, `type` & `val` keys');
+		let isParam = [1, 3].includes(obj.type);
+		t.is(Object.keys(obj).length, isParam ? 5 : 4, '~~> segment has `old`, `type` & `val` keys');
 		t.is(typeof obj.type, 'number', '~~> segment.type is a number');
 		t.is(obj.type, expect[idx].type, '~~> segment.type returns expected value');
 		t.is(typeof obj.val, 'string', '~~> segment.val is a string');
@@ -161,25 +162,25 @@ test('match params (no match, base)', t => {
 
 test('match params (root index-vs-param)', t => {
 	let foo = $.match('/', [$.parse('/')]);
-	t.same(foo[0], { old:'/', type:0, val:'/', end:'', matcher: null }, 'matches root-index route with index-static pattern');
+	t.same(foo[0], { old:'/', type:0, val:'/', end:'' }, 'matches root-index route with index-static pattern');
 
 	let bar = $.match('/', [$.parse('/:title')]);
 	t.is(bar[0], undefined, 'does not match root-index route with param-pattern');
 
 	let baz = $.match('/narnia', [$.parse('/:title')]);
-	t.same(baz[0], { old:'/:title', type:1, val:'title', end:'', matcher: null }, 'matches param-based route with param-pattern');
+	t.same(baz[0], { old:'/:title', type:1, val:'title', end:'', matcher:undefined }, 'matches param-based route with param-pattern');
 
 	let bat = $.match('/', [$.parse('/:title?')]);
-	t.same(bat[0], { old:'/:title?', type:3, val:'title', end:'', matcher: null }, 'matches root-index route with optional-param pattern');
+	t.same(bat[0], { old:'/:title?', type:3, val:'title', end:'', matcher:undefined }, 'matches root-index route with optional-param pattern');
 
 	let quz = $.match('/', [$.parse('*')]);
-	t.same(quz[0], { old:'*', type:2, val:'*', end:'', matcher: null }, 'matches root-index route with root-wilcard pattern');
+	t.same(quz[0], { old:'*', type:2, val:'*', end:'' }, 'matches root-index route with root-wilcard pattern');
 
 	let qut = $.match('/', ['/x', '*'].map($.parse));
-	t.same(qut[0], { old:'*', type:2, val:'*', end:'', matcher: null }, 'matches root-index with wildcard pattern');
+	t.same(qut[0], { old:'*', type:2, val:'*', end:'' }, 'matches root-index with wildcard pattern');
 
 	let qar = $.match('/', ['*', '/x'].map($.parse));
-	t.same(qar[0], { old:'*', type:2, val:'*', end:'', matcher: null }, 'matches root-index with wildcard pattern (reorder)');
+	t.same(qar[0], { old:'*', type:2, val:'*', end:'' }, 'matches root-index with wildcard pattern (reorder)');
 
 	t.end();
 });
@@ -344,7 +345,7 @@ test('match params not a regex (raise error)', t => {
 		bar: 1
 	});
 
-	t.throws(foo, /matcher for bar is not a regex/, 'matcher must be a regex');
+	t.throws(foo, /key is not a RegExp/, 'matcher must be a regex');
 	t.end();
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,7 @@ function isEntry(t, segs, expect) {
 	t.is(segs.length, expect.length, `~> entry has ${expect.length} segment(s)`)
 
 	segs.forEach((obj, idx) => {
-		t.is(Object.keys(obj).length, 4, '~~> segment has `old`, `type` & `val` keys');
+		t.is(Object.keys(obj).length, 5, '~~> segment has `old`, `type` & `val` keys');
 		t.is(typeof obj.type, 'number', '~~> segment.type is a number');
 		t.is(obj.type, expect[idx].type, '~~> segment.type returns expected value');
 		t.is(typeof obj.val, 'string', '~~> segment.val is a string');
@@ -161,25 +161,25 @@ test('match params (no match, base)', t => {
 
 test('match params (root index-vs-param)', t => {
 	let foo = $.match('/', [$.parse('/')]);
-	t.same(foo[0], { old:'/', type:0, val:'/', end:'' }, 'matches root-index route with index-static pattern');
+	t.same(foo[0], { old:'/', type:0, val:'/', end:'', matcher: null }, 'matches root-index route with index-static pattern');
 
 	let bar = $.match('/', [$.parse('/:title')]);
 	t.is(bar[0], undefined, 'does not match root-index route with param-pattern');
 
 	let baz = $.match('/narnia', [$.parse('/:title')]);
-	t.same(baz[0], { old:'/:title', type:1, val:'title', end:'' }, 'matches param-based route with param-pattern');
+	t.same(baz[0], { old:'/:title', type:1, val:'title', end:'', matcher: null }, 'matches param-based route with param-pattern');
 
 	let bat = $.match('/', [$.parse('/:title?')]);
-	t.same(bat[0], { old:'/:title?', type:3, val:'title', end:'' }, 'matches root-index route with optional-param pattern');
+	t.same(bat[0], { old:'/:title?', type:3, val:'title', end:'', matcher: null }, 'matches root-index route with optional-param pattern');
 
 	let quz = $.match('/', [$.parse('*')]);
-	t.same(quz[0], { old:'*', type:2, val:'*', end:'' }, 'matches root-index route with root-wilcard pattern');
+	t.same(quz[0], { old:'*', type:2, val:'*', end:'', matcher: null }, 'matches root-index route with root-wilcard pattern');
 
 	let qut = $.match('/', ['/x', '*'].map($.parse));
-	t.same(qut[0], { old:'*', type:2, val:'*', end:'' }, 'matches root-index with wildcard pattern');
+	t.same(qut[0], { old:'*', type:2, val:'*', end:'', matcher: null }, 'matches root-index with wildcard pattern');
 
 	let qar = $.match('/', ['*', '/x'].map($.parse));
-	t.same(qar[0], { old:'*', type:2, val:'*', end:'' }, 'matches root-index with wildcard pattern (reorder)');
+	t.same(qar[0], { old:'*', type:2, val:'*', end:'', matcher: null }, 'matches root-index with wildcard pattern (reorder)');
 
 	t.end();
 });
@@ -276,7 +276,7 @@ test('exec params', t => {
 	t.end();
 });
 
-test.only('exec params (suffix)', t => {
+test('exec params (suffix)', t => {
 	const arr = $.match('/videos/foo.mp4', PREP);
 	const out = $.exec('/videos/foo.mp4', arr);
 	t.is(typeof out, 'object', 'returns an object');
@@ -336,5 +336,55 @@ test('exec empty (no match)', t => {
 	const out = $.exec('foo', PREP[0]);
 	t.is(typeof out, 'object', 'returns an object');
 	t.is(Object.keys(out).length, 0, 'returns an empty object');
+	t.end();
+});
+
+test('match params not a regex (raise error)', t => {
+	const foo = () => $.parse('/foo/:bar', {
+		bar: 1
+	});
+
+	t.throws(foo, /matcher for bar is not a regex/, 'matcher must be a regex');
+	t.end();
+});
+
+test('match params via matcher (no match)', t => {
+	const foo = $.parse('/foo/:bar', {
+		bar: /[a-z]+/
+	});
+
+	t.is($.match('/foo/1', [foo]).length, 0, 'no match found');
+	t.end();
+});
+
+test('match params via matcher (found match)', t => {
+	const foo = $.parse('/foo/:bar', {
+		bar: /[a-z]+/
+	});
+
+	t.deepEqual($.match('/foo/bar', [foo]), foo);
+	t.end();
+});
+
+test('match params via matcher (optional-param)', t => {
+	const foo = $.parse('/foo/:bar?', {
+		bar: /[a-z]+/
+	});
+
+	t.deepEqual($.match('/foo', [foo]), foo);
+	t.is($.match('/foo/1', [foo]).length, 0);
+	t.end();
+});
+
+test('continue match when matcher regex fails', t => {
+	const foo = $.parse('/foo/:bar?', {
+		bar: /[a-z]+/
+	});
+
+	const foo1 = $.parse('/foo/:id?', {
+		bar: /[0-9]+/
+	});
+
+	t.deepEqual($.match('/foo/1', [foo, foo1]), foo1);
 	t.end();
 });


### PR DESCRIPTION
I have added the support to define matchers to match the dynamic parameters during the `match` operation. ( addresses #9  )

## What are matchers?
Matchers are key/value pairs to define regular expression for matching the params value. The `key` is the param name and `value` is the regex to test it against.

```js
const matchers = {
  bar: /[a-z]/
}

parse('/foo/:bar', matchers)
```

## How it works?

1. Matchers can only be defined for dynamic params (including optionals).
2. A matcher cannot be defined for a wildcard.
3. During the `parse` operation, the matcher for the current value will be attached to it's `node`.
4. During `match` if `matcher` property exists, it will be tested against that.

## PR

- [x] I have added the required tests.
- [ ] Update REAMDE (Not yet, if you are interested in the change, I can update it).
- [ ] Update Benchmarks (Not yet, if you are interested in the change, I can update it).
